### PR TITLE
Include correct header for std::runtime_error

### DIFF
--- a/disruptor/event_processor.h
+++ b/disruptor/event_processor.h
@@ -23,7 +23,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <exception>
+#include <stdexcept>
 
 #include "disruptor/ring_buffer.h"
 


### PR DESCRIPTION
It's declared in `<stdexcept>` not `<exception>`
