### PR TITLE
Use deleted functions to disallow copying

### DIFF
--- a/disruptor/utils.h
+++ b/disruptor/utils.h
@@ -30,7 +30,7 @@
 // A macro to disallow the copy constructor and operator= functions
 // This should be used in the private: declarations for a class
 #define DISALLOW_COPY_AND_ASSIGN(TypeName) \
-  TypeName(const TypeName&);               \
-  void operator=(const TypeName&)
+  TypeName(const TypeName&) = delete;      \
+  void operator=(const TypeName&) = delete
 
 #endif // DISRUPTOR_UTILS_H_ NOLINT

--- a/disruptor/utils.h
+++ b/disruptor/utils.h
@@ -26,9 +26,8 @@
 #ifndef DISRUPTOR_UTILS_H_ // NOLINT
 #define DISRUPTOR_UTILS_H_ // NOLINT
 
-// From Google C++ Standard
-// A macro to disallow the copy constructor and operator= functions
-// This should be used in the private: declarations for a class
+// From Google C++ Standard, modified to use C++11 deleted functions.
+// A macro to disallow the copy constructor and operator= functions.
 #define DISALLOW_COPY_AND_ASSIGN(TypeName) \
   TypeName(const TypeName&) = delete;      \
   void operator=(const TypeName&) = delete


### PR DESCRIPTION
As discussed at https://github.com/fsaintjacques/disruptor--/issues/9#issuecomment-5971732

Rather than removing the macro everywhere I just modified it to use deleted functions.
