### PR TITLE
Fixed non-virtual destructor compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ test-driver
 # generated binaries
 perf/perf-*
 test/*_test
+
+# emacs backups
+*~

--- a/disruptor/batch_descriptor.h
+++ b/disruptor/batch_descriptor.h
@@ -41,6 +41,8 @@ class BatchDescriptor {
         size_(size),
         end_(kInitialCursorValue) {}
 
+    virtual ~BatchDescriptor() {}
+
     // Get the size of the batch
     int size() const { return size_; }
 

--- a/disruptor/claim_strategy.h
+++ b/disruptor/claim_strategy.h
@@ -47,6 +47,8 @@ class SingleThreadedStrategy :  public ClaimStrategyInterface {
         sequence_(kInitialCursorValue),
         min_gating_sequence_(kInitialCursorValue) {}
 
+    virtual ~SingleThreadedStrategy() {}
+
     virtual int64_t IncrementAndGet(
             const std::vector<Sequence*>& dependent_sequences) {
         int64_t next_sequence = sequence_.IncrementAndGet(1L);

--- a/disruptor/event_processor.h
+++ b/disruptor/event_processor.h
@@ -38,6 +38,8 @@ class NoOpEventProcessor : public EventProcessorInterface<T> {
     NoOpEventProcessor(RingBuffer<T>* ring_buffer) :
         ring_buffer_(ring_buffer) { }
 
+    virtual ~NoOpEventProcessor() {}
+
     virtual Sequence* GetSequence() {
         return ring_buffer_->GetSequencePtr();
     }
@@ -63,6 +65,7 @@ class BatchEventProcessor : public EventProcessorInterface<T> {
             event_handler_(event_handler),
             exception_handler_(exception_handler) {}
 
+    virtual ~BatchEventProcessor() {}
 
     virtual Sequence* GetSequence() { return &sequence_; }
 

--- a/disruptor/event_publisher.h
+++ b/disruptor/event_publisher.h
@@ -35,6 +35,8 @@ class EventPublisher {
  public:
     EventPublisher(RingBuffer<T>* ring_buffer) : ring_buffer_(ring_buffer) {}
 
+    virtual ~EventPublisher() {}
+
     void PublishEvent(EventTranslatorInterface<T>* translator) {
         int64_t sequence = ring_buffer_->Next();
         translator->TranslateTo(sequence, ring_buffer_->Get(sequence));

--- a/disruptor/interface.h
+++ b/disruptor/interface.h
@@ -38,6 +38,8 @@ namespace disruptor {
 // {@link Seqencer} by publishers.
 class ClaimStrategyInterface {
  public:
+    virtual ~ClaimStrategyInterface() {}
+
     // Is there available capacity in the buffer for the requested sequence.
     //
     // @param dependent_sequences to be checked for range.
@@ -82,6 +84,8 @@ class ClaimStrategyInterface {
 // dependent {@link EventProcessor}s for processing a data structure.
 class SequenceBarrierInterface {
  public:
+    virtual ~SequenceBarrierInterface() {}
+
     // Wait for the given sequence to be available for consumption.
     //
     // @param sequence to wait for.
@@ -134,6 +138,8 @@ class SequenceBarrierInterface {
 template<typename T>
 class EventFactoryInterface {
  public:
+     virtual ~EventFactoryInterface() {}
+
      virtual T* NewInstance(const int& size) const = 0;
 };
 
@@ -145,6 +151,8 @@ class EventFactoryInterface {
 template<typename T>
 class EventHandlerInterface {
  public:
+    virtual ~EventHandlerInterface() {}
+
     // Called when a publisher has published an event to the {@link RingBuffer}
     //
     // @param event published to the {@link RingBuffer}
@@ -173,12 +181,17 @@ class EventHandlerInterface {
 template<typename T>
 class EventTranslatorInterface {
  public:
+     virtual ~EventTranslatorInterface() {}
+
      // Translate a data representation into fields set in given event
      //
      // @param event into which the data should be translated.
      // @param sequence that is assigned to events.
      // @return the resulting event after it has been translated.
      virtual T* TranslateTo(const int64_t& sequence, T* event) = 0;
+
+ private:
+     DISALLOW_COPY_AND_ASSIGN(EventTranslatorInterface);
 };
 
 // EventProcessors wait for events to become available for consumption from
@@ -190,6 +203,8 @@ class EventTranslatorInterface {
 template<typename T>
 class EventProcessorInterface {
  public:
+     virtual ~EventProcessorInterface() {}
+
      // Get a pointer to the {@link Sequence} being used by this
      // {@link EventProcessor}.
      //
@@ -211,6 +226,8 @@ class EventProcessorInterface {
 template<typename T>
 class ExceptionHandlerInterface {
  public:
+    virtual ~ExceptionHandlerInterface() {}
+
     // Strategy for handling uncaught exceptions when processing an event.
     // If the strategy wishes to suspend further processing by the
     // {@link BatchEventProcessor} then it should throw a std::runtime_error.
@@ -227,6 +244,8 @@ class ExceptionHandlerInterface {
 // {@link Sequence}.
 class WaitStrategyInterface {
  public:
+    virtual ~WaitStrategyInterface() {}
+
     //  Wait for the given sequence to be available for consumption.
     //
     //  @param dependents further back the chain that must advance first.

--- a/disruptor/ring_buffer.h
+++ b/disruptor/ring_buffer.h
@@ -67,7 +67,7 @@ class RingBuffer : public Sequencer {
             events_(event_factory->NewInstance(buffer_size)) {
     }
 
-    ~RingBuffer() {
+    virtual ~RingBuffer() {
         delete[] events_;
     }
 

--- a/disruptor/sequence.h
+++ b/disruptor/sequence.h
@@ -51,6 +51,8 @@ class Sequence {
     Sequence(int64_t initial_value = kInitialCursorValue) :
             value_(initial_value) {}
 
+    virtual ~Sequence() {}
+
     // Get the current value of the {@link Sequence}.
     //
     // @return the current value.
@@ -85,6 +87,8 @@ class PaddedSequence : public Sequence {
     PaddedSequence(int64_t initial_value = kInitialCursorValue) :
             Sequence(initial_value) {}
 
+    virtual ~PaddedSequence() {}
+
  private:
     // padding
     int64_t padding_[ATOMIC_SEQUENCE_PADDING_LENGTH];
@@ -100,6 +104,8 @@ class MutableLong {
      MutableLong(int64_t initial_value = kInitialCursorValue) :
          sequence_(initial_value) {}
 
+     virtual ~MutableLong() {}
+
      int64_t sequence() const { return sequence_; }
 
      void set_sequence(const int64_t& sequence) { sequence_ = sequence; };
@@ -108,6 +114,7 @@ class MutableLong {
 
  private:
      volatile int64_t sequence_;
+     DISALLOW_COPY_AND_ASSIGN(MutableLong);
 };
 
 // Cache line padded non-atomic sequence counter.
@@ -117,8 +124,12 @@ class PaddedLong : public MutableLong {
  public:
      PaddedLong(int64_t initial_value = kInitialCursorValue) :
          MutableLong(initial_value) {}
+
+     virtual ~PaddedLong() {}
+
  private:
      int64_t padding_[SEQUENCE_PADDING_LENGTH];
+     DISALLOW_COPY_AND_ASSIGN(PaddedLong);
 };
 
 int64_t GetMinimumSequence(

--- a/disruptor/sequence_barrier.h
+++ b/disruptor/sequence_barrier.h
@@ -45,6 +45,8 @@ class ProcessingSequenceBarrier : SequenceBarrierInterface {
         alerted_(false) {
     }
 
+    virtual ~ProcessingSequenceBarrier() {}
+
     virtual int64_t WaitFor(const int64_t& sequence) {
         return wait_strategy_->WaitFor(dependent_sequences_, *cursor_, *this,
                                        sequence);
@@ -82,6 +84,7 @@ class ProcessingSequenceBarrier : SequenceBarrierInterface {
     Sequence* cursor_;
     std::vector<Sequence*> dependent_sequences_;
     std::atomic<bool> alerted_;
+    DISALLOW_COPY_AND_ASSIGN(ProcessingSequenceBarrier);
 };
 
 };  // namespace disruptor

--- a/disruptor/sequencer.h
+++ b/disruptor/sequencer.h
@@ -55,7 +55,7 @@ class Sequencer {
                                                 buffer_size_)),
             wait_strategy_(CreateWaitStrategy(wait_strategy_option)) { }
 
-    ~Sequencer() {
+    virtual ~Sequencer() {
         delete claim_strategy_;
         delete wait_strategy_;
     }

--- a/disruptor/wait_strategy.h
+++ b/disruptor/wait_strategy.h
@@ -65,6 +65,8 @@ class BlockingStrategy :  public WaitStrategyInterface {
  public:
     BlockingStrategy() {}
 
+    virtual ~BlockingStrategy() {}
+
     virtual int64_t WaitFor(const std::vector<Sequence*>& dependents,
                             const Sequence& cursor,
                             const SequenceBarrierInterface& barrier,
@@ -134,6 +136,8 @@ class BlockingStrategy :  public WaitStrategyInterface {
 class SleepingStrategy :  public WaitStrategyInterface {
  public:
     SleepingStrategy() {}
+
+    virtual ~SleepingStrategy() {}
 
     virtual int64_t WaitFor(const std::vector<Sequence*>& dependents,
                             const Sequence& cursor,
@@ -220,6 +224,8 @@ class YieldingStrategy :  public WaitStrategyInterface {
  public:
     YieldingStrategy() {}
 
+    virtual ~YieldingStrategy() {}
+
     virtual int64_t WaitFor(const std::vector<Sequence*>& dependents,
                             const Sequence& cursor,
                             const SequenceBarrierInterface& barrier,
@@ -303,6 +309,8 @@ class YieldingStrategy :  public WaitStrategyInterface {
 class BusySpinStrategy :  public WaitStrategyInterface {
  public:
     BusySpinStrategy() {}
+
+    virtual ~BusySpinStrategy() {}
 
     virtual int64_t WaitFor(const std::vector<Sequence*>& dependents,
                             const Sequence& cursor,


### PR DESCRIPTION
Please take a look when you have a chance. Simple fix to get rid of some annoying compiler warnings.