### PR TITLE
fix #36:  fix broken BlockingStrategy

### DIFF
--- a/disruptor/sequence_barrier.h
+++ b/disruptor/sequence_barrier.h
@@ -37,9 +37,9 @@ namespace disruptor {
 template <typename W = kDefaultWaitStrategy>
 class SequenceBarrier {
  public:
-  SequenceBarrier(const Sequence& cursor,
+  SequenceBarrier(W& wait_strategy, const Sequence& cursor,
                   const std::vector<Sequence*>& dependents)
-      : cursor_(cursor), dependents_(dependents), alerted_(false) {}
+      : wait_strategy_(wait_strategy) cursor_(cursor), dependents_(dependents), alerted_(false) {}
 
   int64_t WaitFor(const int64_t& sequence) {
     return wait_strategy_.WaitFor(sequence, cursor_, dependents_, alerted_);
@@ -63,7 +63,7 @@ class SequenceBarrier {
   }
 
  private:
-  W wait_strategy_;
+  W& wait_strategy_;
   const Sequence& cursor_;
   std::vector<Sequence*> dependents_;
   std::atomic<bool> alerted_;

--- a/disruptor/sequencer.h
+++ b/disruptor/sequencer.h
@@ -55,7 +55,7 @@ class Sequencer {
   // @param sequences_to_track this barrier will track.
   // @return the barrier gated as required.
   SequenceBarrier<W> NewBarrier(const std::vector<Sequence*>& dependents) {
-    return SequenceBarrier<W>(cursor_, dependents);
+    return SequenceBarrier<W>(wait_strategy_, cursor_, dependents);
   }
 
   // Get the value of the cursor indicating the published sequence.


### PR DESCRIPTION
There are 2 BlockingStrategy instance in Sequencer and SequenceBarrier, so the BlockingStrategy won't work.
The SequenceBarrier shall hold the reference to the `wait_strategy_` in the sequencer instance, instead of having it's own instance. 